### PR TITLE
Brought the volume of the test tone down.

### DIFF
--- a/modules/juce_audio_devices/audio_io/juce_AudioDeviceManager.cpp
+++ b/modules/juce_audio_devices/audio_io/juce_AudioDeviceManager.cpp
@@ -1077,7 +1077,7 @@ void AudioDeviceManager::playTestSound()
         auto soundLength = (int) sampleRate;
 
         double frequency = 440.0;
-        float amplitude = 0.5f;
+        float amplitude = 0.25f;
 
         auto phasePerSample = MathConstants<double>::twoPi / (sampleRate / frequency);
 


### PR DESCRIPTION
The task said max -20 dBFS. This was still clipping on my laptop speakers so I just chose a number by ear. Happy to bring it down more if it still seems to loud on other devices.