### PR TITLE
* fixed TreeView ScrollToKeepItemVisible broken in current juce

### DIFF
--- a/modules/juce_gui_basics/widgets/juce_TreeView.cpp
+++ b/modules/juce_gui_basics/widgets/juce_TreeView.cpp
@@ -703,7 +703,7 @@ public:
         return static_cast<ContentComponent*> (getViewedComponent());
     }
 
-    enum class Async { yes, no };
+    // PSE (moved Async decl. to header)
 
     void recalculatePositions (Async useAsyncUpdate)
     {
@@ -816,7 +816,7 @@ void TreeView::setRootItem (TreeViewItem* const newRootItem)
             rootItem->setOpen (true);
         }
 
-        viewport->recalculatePositions (TreeViewport::Async::no);
+        viewport->recalculatePositions (Async::no);
     }
 }
 
@@ -1057,7 +1057,8 @@ void TreeView::scrollToKeepItemVisible (TreeViewItem* item)
 {
     if (item != nullptr && item->ownerView == this)
     {
-        updateVisibleItems();
+        // PSE (made synchronous so that the updated positions are actually relevant below)
+        updateVisibleItems(Async::no);
 
         item = item->getDeepestOpenParentItem();
 
@@ -1174,9 +1175,10 @@ bool TreeView::keyPressed (const KeyPress& key)
     return false;
 }
 
-void TreeView::updateVisibleItems()
+// PSE (added optional syncronous)
+void TreeView::updateVisibleItems(Async useAsyncUpdate)
 {
-    viewport->recalculatePositions (TreeViewport::Async::yes);
+    viewport->recalculatePositions (useAsyncUpdate);
 }
 
 //==============================================================================

--- a/modules/juce_gui_basics/widgets/juce_TreeView.h
+++ b/modules/juce_gui_basics/widgets/juce_TreeView.h
@@ -925,6 +925,9 @@ public:
 private:
     friend class TreeViewItem;
 
+    // PSE (moved from def.)
+    enum class Async { yes, no };
+
     class ItemComponent;
     class ContentComponent;
     class TreeViewport;
@@ -935,7 +938,7 @@ private:
 
     std::unique_ptr<AccessibilityHandler> createAccessibilityHandler() override;
     void itemsChanged() noexcept;
-    void updateVisibleItems();
+    void updateVisibleItems(Async useAsyncUpdate = Async::yes);
     void updateButtonUnderMouse (const MouseEvent&);
     void showDragHighlight (const InsertPoint&) noexcept;
     void hideDragHighlight() noexcept;


### PR DESCRIPTION
not entirely sure this is the exact branch dev is based off or which is supposed to be our dev juce branch, so go ahead and change base accordingly.