### PR TITLE
* fixed PSE version of AudioThumbnail to prevent thumbnail render thr…

### DIFF
--- a/modules/juce_audio_utils/gui/juce_AudioThumbnail.cpp
+++ b/modules/juce_audio_utils/gui/juce_AudioThumbnail.cpp
@@ -243,9 +243,13 @@ private:
 
             // PSE
             // if numSamplesFinished + numToDo > progressInSamples, then not all downloads
-            if ((numSamplesFinished + numToDo) > floor(lengthInSamples * fileStreamProgress.load()))
+            // dd: note: we need to give the fileProgress a full buffer head start, or the
+            // thumbnail could easily catch-up / overrun in the middle of a buffer.
+            auto fileProgress = floor(lengthInSamples * fileStreamProgress.load()) - numToDo;
+            if ((numSamplesFinished + numToDo) > fileProgress)
             {
-                return isFullyLoaded();
+                if (!((lengthInSamples - numSamplesFinished) < numToDo * 2))
+                    return isFullyLoaded();
             }
             //
             


### PR DESCRIPTION
…ead from overrunning audio download stream thread (samplesRendered > samplesDownloaded)