### PR TITLE
* fixed crash in aiffFormat metadata writer.

### DIFF
--- a/modules/juce_audio_formats/codecs/juce_AiffAudioFormat.cpp
+++ b/modules/juce_audio_formats/codecs/juce_AiffAudioFormat.cpp
@@ -1178,7 +1178,7 @@ namespace AiffFileHelpers
         TemporaryFile tempFile (file);
         AiffAudioFormat aiff;
         
-        std::unique_ptr<AudioFormatReader> reader (aiff.createReaderFor (file.createInputStream().get(), true)); //JOHN check this works JUCE 6
+        std::unique_ptr<AudioFormatReader> reader (aiff.createReaderFor (file.createInputStream().release(), true)); // Make sure to release the stream pointer to the reader or else it will go out of scope here, and crash there!
         
         if (reader != nullptr)
         {


### PR DESCRIPTION
oy...  I have no idea which juce branch is which anymore...  unfortunately none of my IDE provide the actual branch name just the garbage tag number which doesn't seem to match any tag numbers in the repo or origin...
Which branch is is submodule of collection-mega? which branch is attached to SoundQ dev?  Which branch do we use for juce dev?  Can we at least give them more meaningful names since I am too stupid to find them by tags?

Anyway, the fix is self explanatory.